### PR TITLE
Fix memory leak in main page

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -377,7 +377,7 @@
                                         <div class="accordion" id="detailEXSoSAccordion">
                                             <div class="accordion-item">
                                                 <h2 class="accordion-header">
-                                                    <button class="accordion-button collapsed" type="button"
+                                                    <button class="accordion-button" type="button"
                                                         data-bs-toggle="collapse"
                                                         data-bs-target="#detailEXSoSAccordionCollapseOne"
                                                         aria-expanded="true"
@@ -386,8 +386,8 @@
                                                     </button>
                                                 </h2>
                                                 <div id="detailEXSoSAccordionCollapseOne"
-                                                    class="accordion-collapse collapse" aria-labelledby="headingOne"
-                                                    data-bs-parent="#detailEXSoSAccordion">
+                                                    class="accordion-collapse collapse show"
+                                                    aria-labelledby="headingOne" data-bs-parent="#detailEXSoSAccordion">
                                                     <div class="accordion-body">
                                                         <div class="row">
                                                             <div class="col">


### PR DESCRIPTION
- 메인 페이지의 메모리 누수는 상세 EXSoS 안전도 차트의 문제로 보임.
  - Bootstrap 컴포넌트 중 Accordion을 이용한 '상세 보기'를 활성화 상태로 변경했을 경우 메모리 누수 문제를 해결함.
  - 정확한 원인을 파악하기 힘듬... (Bootstrap 및 AMCharts 연동 이슈로 보임)

**_메인 페이지 개발자 도구 Performance(Memory leak 의심)_**
![메인 페이지 개발자 도구 Performance(Memory leak 의심)](https://user-images.githubusercontent.com/51071806/221796523-8b3962f5-a29b-4dcc-ad53-cb038beb74b7.jpg)

**_메인 페이지 개발자 도구 Performance(정상)_**
![메인 페이지 개발자 도구 Performance(정상)](https://user-images.githubusercontent.com/51071806/221796583-bd257434-65cb-414b-9987-0d9b7364e136.jpg)

**_브라우저 작업 관리자 화면(정상)_**
![브라우저 작업 관리자 화면(정상)](https://user-images.githubusercontent.com/51071806/221796620-8d8ce116-7d30-4b93-814d-9e02ba52deea.jpg)